### PR TITLE
Ungroup targets table

### DIFF
--- a/R/ipu.R
+++ b/R/ipu.R
@@ -603,6 +603,7 @@ compare_results <- function(seed, targets){
     
     # Gather the current target table into long form
     target <- target %>%
+      dplyr::ungroup() %>%
       dplyr::mutate(geo = paste0(geo_colname, "_", !!as.name(geo_colname))) %>%
       dplyr::select(-dplyr::one_of(geo_colname)) %>%
       tidyr::gather(key = category, value = target, -geo) %>%


### PR DESCRIPTION
It might be wiser to add a check that the tables are `ungroup()`ed; otherwise the `select()` statement keeps the grouping variable on the data and prevents your gather from working appropriately.